### PR TITLE
Debug local page error

### DIFF
--- a/server.js
+++ b/server.js
@@ -154,7 +154,7 @@ const galleryUpload = multer({
 // CONFIGURACIÓN NODEMAILER
 // ========================
 
-const transporter = nodemailer.createTransporter({
+const transporter = nodemailer.createTransport({
     host: process.env.EMAIL_HOST || 'smtp.gmail.com',
     port: parseInt(process.env.EMAIL_PORT) || 587,
     secure: process.env.EMAIL_SECURE === 'true', // true para 465, false para otros puertos
@@ -493,7 +493,7 @@ app.post('/api/contacto', async (req, res) => {
 
 // Servir la página principal
 app.get('/', (req, res) => {
-    res.sendFile(path.join(__dirname, 'public', 'dajusca.html'));
+    res.sendFile(path.join(__dirname, 'dajusca.html'));
 });
 
 // Manejo de errores global


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix server errors by correcting Nodemailer method and the path to the main HTML file.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The server was failing due to two issues: an incorrect method call for Nodemailer (`createTransporter` instead of `createTransport`) and an incorrect path for serving `dajusca.html`, which was expected in a `public` directory but was located in the project root. These fixes resolve the 500 Internal Server Error.

---
<a href="https://cursor.com/background-agent?bcId=bc-b6487068-f3ee-4ecf-8dfe-b91f5c7300c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b6487068-f3ee-4ecf-8dfe-b91f5c7300c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>